### PR TITLE
feat: add option to parse JSON in environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This modules provides CLI commands to be used in [NPM scripts](https://docs.npmj
 
 ### Export environment variables to a JSON or JavaScript file
 
-`ngx-scripts env <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--parseJson]`
+`ngx-scripts env <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--parse-json]`
 
 Default output file is `src/environments/.env.ts` with JavaScript format.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This modules provides CLI commands to be used in [NPM scripts](https://docs.npmj
 
 ### Export environment variables to a JSON or JavaScript file
 
-`ngx-scripts env <env_var> [<env_var2> ...] [--out <file>] [--format json|js]`
+`ngx-scripts env <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--parseJson]`
 
 Default output file is `src/environments/.env.ts` with JavaScript format.
 
@@ -52,6 +52,7 @@ Any accepted Cordova option can be passed through after `--`.
 - `--release`: Create a Cordova release build
 - `--verbose`: Show Cordova debug output
 - `--yarn`: Use [Yarn](https://yarnpkg.com) instead of NPM to run the `build` script
+- `--parseJson`: During `env`, if an environment variable's value is parsable JSON, it will be a proper object in `.env.ts`
 
 > Note: Yarn is automatically used instead of NPM is the environment variable `NGX_PACKAGE_MANAGER` is set to `yarn` or
 > if the current project was generated with ngX-Rocket using Yarn option (option is saved in `.yo-rc.json`).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Any accepted Cordova option can be passed through after `--`.
 - `--release`: Create a Cordova release build
 - `--verbose`: Show Cordova debug output
 - `--yarn`: Use [Yarn](https://yarnpkg.com) instead of NPM to run the `build` script
-- `--parseJson`: During `env`, if an environment variable's value is parsable JSON, it will be a proper object in `.env.ts`
+- `--parse-json`: During `env`, if an environment variable's value is parsable JSON, it will be a proper object in `.env.ts`
 
 > Note: Yarn is automatically used instead of NPM is the environment variable `NGX_PACKAGE_MANAGER` is set to `yarn` or
 > if the current project was generated with ngX-Rocket using Yarn option (option is saved in `.yo-rc.json`).

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ class NgxScriptsCli {
         'cordova',
         'dist',
         'verbose',
-        'parseJson'
+        'parse-json'
       ],
       string: [
         'out',

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const help = `${chalk.bold('Usage')} ${appName} ${chalk.blue(
 const detailedHelp = `
 ${chalk.blue(
   'env'
-)} <env_var> [<env_var2> ...] [--out <file>] [--format json|js]
+)} <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--preserveJson]
   Export environment variables to a JSON or JavaScript file.
   Default output file is ${chalk.cyan('src/environments/.env.ts')}
 
@@ -72,7 +72,8 @@ class NgxScriptsCli {
         'yarn',
         'cordova',
         'dist',
-        'verbose'
+        'verbose',
+        'preserveJson'
       ],
       string: [
         'out',
@@ -103,7 +104,8 @@ class NgxScriptsCli {
         return this._env(
           this._options._.slice(1),
           this._options.out,
-          this._options.format
+          this._options.format,
+          this._options.preserveJson
         );
       case 'cordova':
         return this._cordova(this._options);
@@ -114,7 +116,12 @@ class NgxScriptsCli {
     }
   }
 
-  _env(vars, outputFile = 'src/environments/.env.ts', format = 'js') {
+  _env(
+    vars,
+    outputFile = 'src/environments/.env.ts',
+    format = 'js',
+    preserveJson = false
+  ) {
     if (vars.length === 0) {
       this._exit(`${chalk.red('Missing arguments')}\n`);
     }
@@ -122,6 +129,12 @@ class NgxScriptsCli {
     let env = JSON.stringify(
       vars.reduce((env, v) => {
         env[v] = process.env[v] === undefined ? null : process.env[v];
+        if (preserveJson) {
+          try {
+            env[v] = JSON.parse(env[v]);
+          } catch {}
+        }
+
         return env;
       }, {}),
       null,
@@ -134,7 +147,9 @@ class NgxScriptsCli {
         const s = v.replace(/'/g, "\\'").replace(/\\"/g, '"');
         return `'${s}'`;
       });
-      env = `export const env: { [s: string]: (string | null); } = ${env};\n`;
+      env = `export const env: { [s: string]: (${
+        preserveJson ? `any` : `string`
+      } | null); } = ${env};\n`;
     }
 
     try {

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ class NgxScriptsCli {
           this._options._.slice(1),
           this._options.out,
           this._options.format,
-          this._options.parseJson
+          this._options['parse-json']
         );
       case 'cordova':
         return this._cordova(this._options);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const help = `${chalk.bold('Usage')} ${appName} ${chalk.blue(
 const detailedHelp = `
 ${chalk.blue(
   'env'
-)} <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--preserveJson]
+)} <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--parseJson]
   Export environment variables to a JSON or JavaScript file.
   Default output file is ${chalk.cyan('src/environments/.env.ts')}
 
@@ -73,7 +73,7 @@ class NgxScriptsCli {
         'cordova',
         'dist',
         'verbose',
-        'preserveJson'
+        'parseJson'
       ],
       string: [
         'out',
@@ -105,7 +105,7 @@ class NgxScriptsCli {
           this._options._.slice(1),
           this._options.out,
           this._options.format,
-          this._options.preserveJson
+          this._options.parseJson
         );
       case 'cordova':
         return this._cordova(this._options);
@@ -120,7 +120,7 @@ class NgxScriptsCli {
     vars,
     outputFile = 'src/environments/.env.ts',
     format = 'js',
-    preserveJson = false
+    parseJson = false
   ) {
     if (vars.length === 0) {
       this._exit(`${chalk.red('Missing arguments')}\n`);
@@ -129,7 +129,7 @@ class NgxScriptsCli {
     let env = JSON.stringify(
       vars.reduce((env, v) => {
         env[v] = process.env[v] === undefined ? null : process.env[v];
-        if (preserveJson) {
+        if (parseJson) {
           try {
             env[v] = JSON.parse(env[v]);
           } catch {}
@@ -148,7 +148,7 @@ class NgxScriptsCli {
         return `'${s}'`;
       });
       env = `export const env: { [s: string]: (${
-        preserveJson ? `any` : `string`
+        parseJson ? `any` : `string`
       } | null); } = ${env};\n`;
     }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const help = `${chalk.bold('Usage')} ${appName} ${chalk.blue(
 const detailedHelp = `
 ${chalk.blue(
   'env'
-)} <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--parseJson]
+)} <env_var> [<env_var2> ...] [--out <file>] [--format json|js] [--parse-json]
   Export environment variables to a JSON or JavaScript file.
   Default output file is ${chalk.cyan('src/environments/.env.ts')}
 


### PR DESCRIPTION
I have a case where I have a more complex object I'd like to inject into the environment, such as a map of multiple micro services:

```
{
"Service1ApiUrl": "https://example.com/service1/api",
"Service2ApiUrl": "https://example.com/service2/api"
}
```

This would be saved as an escaped JSON string in the environment:

```
export TEST_ENV_VAR="hello world"
export TEST_JSON_ENV_VAR="{\"Service1ApiUrl\":\"https:\/\/example.com\/service1\/api\",\"Service2ApiUrl\":\"https:\/\/example.com\/service2\/api\"}"
```

This PR allows for the parsing of JSON strings, if the `--parseJson` flag is set.

Before + Backwards Compatible, without the flag: 

`./bin/ngx-scripts env TEST_ENV_VAR TEST_JSON_ENV_VAR`:

```
export const env: { [s: string]: (string | null); } = {
  'TEST_ENV_VAR': 'hello world',
  'TEST_JSON_ENV_VAR': '{"Service1ApiUrl":"https:\\/\\/example.com\\/service1\\/api","Service2ApiUrl":"https:\\/\\/example.com\\/service2\\/api"}'
};
```

NEW with the flag:

`./bin/ngx-scripts env TEST_ENV_VAR TEST_JSON_ENV_VAR --parseJson`:

```
export const env: { [s: string]: (any | null); } = {
  'TEST_ENV_VAR': 'hello world',
  'TEST_JSON_ENV_VAR': {
    'Service1ApiUrl': 'https://example.com/service1/api',
    'Service2ApiUrl': 'https://example.com/service2/api'
  }
};
```

Notable changes:
 - Object type is now `any` when the flag is enabled
 - JSON is parsed, if possible, otherwise fallback to original logic

Thoughts? Feelings? Feedback?